### PR TITLE
fix: correct AdoptionCenter model XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Dog World is a pet simulation game where players can adopt, collect, and care fo
 
 All core gameplay features have been implemented. The next step is to replace the placeholder building and dog models with higher-quality assets from the Roblox Creator Marketplace.
 
+### Recent Fixes
+
+- Resolved malformed XML in `src/buildings/AdoptionCenter.rbxmx` that prevented `rojo serve` from running.
+
 ## Getting Started
 To build the place from scratch, use:
 

--- a/src/buildings/AdoptionCenter.rbxmx
+++ b/src/buildings/AdoptionCenter.rbxmx
@@ -9,7 +9,7 @@
 				<bool name="Anchored">true</bool>
 				<Color3 name="Color"><R>1</R><G>0.8</G><B>0.8</B></Color3>
 				<Vector3 name="Size"><X>20</X><Y>10</Y><Z>1</Z></Vector3>
-				<CoordinateFrame name="CFrame"><![CDATA[1 0 0 0 1 0 0 0 1 0 5 -10]]></CoordinateFrame>
+                                <CoordinateFrame name="CFrame">1 0 0 0 1 0 0 0 1 0 5 -10</CoordinateFrame>
 			</Properties>
 		</Item>
 		<Item class="Part" referent="RBX2">


### PR DESCRIPTION
## Summary
- replace invalid CDATA in AdoptionCenter model with proper CoordinateFrame value
- note recent fix in README

## Testing
- `rojo build -o tmp.rbxlx` *(fails: command not found)*
- `curl -L -o rojo.zip https://github.com/rojo-rbx/rojo/releases/download/v7.5.1/rojo-7.5.1-linux-x86_64.zip && unzip rojo.zip && mv rojo /usr/local/bin/rojo && rm rojo.zip` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68969db3dd14832188f49247d9f272b3