### PR TITLE
Fix AdoptionCenter CFrame XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All core gameplay features have been implemented. The next step is to replace th
 
 ### Recent Fixes
 
-- Resolved malformed XML in `src/buildings/AdoptionCenter.rbxmx` that prevented `rojo serve` from running.
+- Fixed the `CFrame` property in `src/buildings/AdoptionCenter.rbxmx` by expanding it into explicit rotation and position fields, resolving malformed XML that prevented `rojo serve` from running.
 
 ## Getting Started
 To build the place from scratch, use:
@@ -41,3 +41,4 @@ rojo serve
 ```
 
 For more help, check out [the Rojo documentation](https://rojo.space/docs).
+

--- a/src/buildings/AdoptionCenter.rbxmx
+++ b/src/buildings/AdoptionCenter.rbxmx
@@ -8,8 +8,21 @@
 				<string name="Name">Wall1</string>
 				<bool name="Anchored">true</bool>
 				<Color3 name="Color"><R>1</R><G>0.8</G><B>0.8</B></Color3>
-				<Vector3 name="Size"><X>20</X><Y>10</Y><Z>1</Z></Vector3>
-                                <CoordinateFrame name="CFrame">1 0 0 0 1 0 0 0 1 0 5 -10</CoordinateFrame>
+                                <Vector3 name="Size"><X>20</X><Y>10</Y><Z>1</Z></Vector3>
+                                <CoordinateFrame name="CFrame">
+                                        <R00>1</R00>
+                                        <R01>0</R01>
+                                        <R02>0</R02>
+                                        <R10>0</R10>
+                                        <R11>1</R11>
+                                        <R12>0</R12>
+                                        <R20>0</R20>
+                                        <R21>0</R21>
+                                        <R22>1</R22>
+                                        <X>0</X>
+                                        <Y>5</Y>
+                                        <Z>-10</Z>
+                                </CoordinateFrame>
 			</Properties>
 		</Item>
 		<Item class="Part" referent="RBX2">


### PR DESCRIPTION
## Summary
- expand CFrame in AdoptionCenter to explicit rotation/position fields
- document AdoptionCenter CFrame fix in README

## Testing
- `rojo build -o "gag_gpt5.rbxlx"` *(fails: command not found)*
- `cargo install rojo --version 7.5.1` *(fails: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('src/buildings/AdoptionCenter.rbxmx')
print('XML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6896a0649b688321a4152bc0b616d481