### PR TITLE
Fix AdoptionCenter CFrame XML ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All core gameplay features have been implemented. The next step is to replace th
 
 ### Recent Fixes
 
-- Fixed the `CFrame` property in `src/buildings/AdoptionCenter.rbxmx` by expanding it into explicit rotation and position fields, resolving malformed XML that prevented `rojo serve` from running.
+- Reordered the `CFrame` elements in `src/buildings/AdoptionCenter.rbxmx` so that position fields precede rotation components, resolving the malformed XML error that prevented `rojo serve` from running.
 
 ## Getting Started
 To build the place from scratch, use:
@@ -41,4 +41,5 @@ rojo serve
 ```
 
 For more help, check out [the Rojo documentation](https://rojo.space/docs).
+
 

--- a/src/buildings/AdoptionCenter.rbxmx
+++ b/src/buildings/AdoptionCenter.rbxmx
@@ -10,6 +10,9 @@
 				<Color3 name="Color"><R>1</R><G>0.8</G><B>0.8</B></Color3>
                                 <Vector3 name="Size"><X>20</X><Y>10</Y><Z>1</Z></Vector3>
                                 <CoordinateFrame name="CFrame">
+                                        <X>0</X>
+                                        <Y>5</Y>
+                                        <Z>-10</Z>
                                         <R00>1</R00>
                                         <R01>0</R01>
                                         <R02>0</R02>
@@ -19,12 +22,9 @@
                                         <R20>0</R20>
                                         <R21>0</R21>
                                         <R22>1</R22>
-                                        <X>0</X>
-                                        <Y>5</Y>
-                                        <Z>-10</Z>
                                 </CoordinateFrame>
-			</Properties>
-		</Item>
+                        </Properties>
+                </Item>
 		<Item class="Part" referent="RBX2">
 			<Properties>
 				<string name="Name">Wall2</string>


### PR DESCRIPTION
## Summary
- reorder position and rotation elements in AdoptionCenter CFrame to satisfy Rojo's expected XML schema and avoid malformed XML errors
- document the CFrame fix in the README

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('src/buildings/AdoptionCenter.rbxmx')
print('ok')
PY`
- `cargo install rojo` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896a23777d08321b41a042df0353761