### PR TITLE
feat: add roaming stray dogs, speed up testing, show wallet, and tag assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ Dog World is a pet simulation game where players can adopt, collect, and care fo
 ### Core Features
 
 - **Pet Adoption:** Adopt dogs through different methods:
-  - **Snack Machine:** An automatic machine that attracts stray dogs every 10 seconds.
-  - **Adoption Center:** A center that restocks with 10 new dogs every 25 minutes, available for purchase with DogCoins.
+  - **Snack Machine:** An automatic machine that attracts stray dogs every 10 seconds. *(Unique ID: 1ac654213aa2686d08a84957000039b7)*
+  - **Adoption Center:** A center that restocks with 10 new dogs every minute (testing) available for purchase with DogCoins. *(UI Unique ID: 1ac654213aa2686d08a849570000224d)*
   - **Premium Shop:** A special shop to purchase limited edition dogs with Robux.
+- **Stray Dogs:** Various stray dogs wander the world and can be found roaming around.
+- **Dog Models:** All dog models are tagged with unique IDs for asset tracking (1ac654213aa2686d08a8495700003cb1, 1ac654213aa2686d08a8495700003d3d, 1ac654213aa2686d08a8495700003ec7, 1ac654213aa2686d08a8495700003f40).
 - **Economy System:**
-  - **DogCoins:** The primary in-game currency. Players automatically receive 500 DogCoins every 3 minutes.
+  - **DogCoins:** The primary in-game currency. Players automatically receive 500 DogCoins every minute (testing).
   - **Robux:** Used for purchasing exclusive, limited-edition dogs.
-- **Dog Requests:** Your dogs will occasionally have requests (e.g., playing, eating). Fulfilling these requests rewards you with DogCoins.
+  - **Wallet Display:** The player's current DogCoin balance is always visible on screen. *(Unique ID: 1ac654213aa2686d08a8495700003bcb)*
+- **Dog Requests:** Your dogs will occasionally have requests (e.g., playing, eating). Fulfilling these requests rewards you with DogCoins. During testing, these occur every 30–60 seconds.
 
 ## Current Status
 
@@ -26,6 +29,9 @@ All core gameplay features have been implemented. The next step is to replace th
 ### Recent Fixes
 
 - Reordered the `CFrame` elements in `src/buildings/AdoptionCenter.rbxmx` so that position fields precede rotation components, resolving the malformed XML error that prevented `rojo serve` from running.
+- Added roaming stray dogs and expanded the list of available breeds.
+- Shortened in-game timers to one minute for faster testing.
+- Tagged the adoption UI, pet snack machine, DogCoin wallet, and dog models with unique IDs for asset tracking.
 
 ## Getting Started
 To build the place from scratch, use:

--- a/src/client/AdoptionCenterGui.luau
+++ b/src/client/AdoptionCenterGui.luau
@@ -10,6 +10,7 @@ local playerGui = player:WaitForChild("PlayerGui")
 -- Main GUI
 local screenGui = Instance.new("ScreenGui", playerGui)
 screenGui.Name = "AdoptionCenterGui"
+screenGui:SetAttribute("uniqueID", "1ac654213aa2686d08a849570000224d")
 
 -- Adoption Center UI
 local mainFrame = Instance.new("Frame", screenGui)

--- a/src/client/CoinDisplay.luau
+++ b/src/client/CoinDisplay.luau
@@ -8,21 +8,22 @@ local player = Players.LocalPlayer
 local playerGui = player:WaitForChild("PlayerGui")
 
 local screenGui = Instance.new("ScreenGui", playerGui)
-screenGui.Name = "DogCoinGui"
+screenGui.Name = "WalletGui"
+screenGui:SetAttribute("uniqueID", "1ac654213aa2686d08a8495700003bcb")
 
-local coinLabel = Instance.new("TextLabel", screenGui)
-coinLabel.Name = "CoinLabel"
-coinLabel.Size = UDim2.new(0, 200, 0, 50)
-coinLabel.Position = UDim2.new(0, 10, 0, 10)
-coinLabel.BackgroundColor3 = Color3.new(0, 0, 0)
-coinLabel.BackgroundTransparency = 0.5
-coinLabel.TextColor3 = Color3.new(1, 1, 1)
-coinLabel.Font = Enum.Font.SourceSansBold
-coinLabel.TextSize = 24
-coinLabel.Text = "DogCoins: ..."
+local walletLabel = Instance.new("TextLabel", screenGui)
+walletLabel.Name = "WalletLabel"
+walletLabel.Size = UDim2.new(0, 200, 0, 50)
+walletLabel.Position = UDim2.new(0, 10, 0, 10)
+walletLabel.BackgroundColor3 = Color3.new(0, 0, 0)
+walletLabel.BackgroundTransparency = 0.5
+walletLabel.TextColor3 = Color3.new(1, 1, 1)
+walletLabel.Font = Enum.Font.SourceSansBold
+walletLabel.TextSize = 24
+walletLabel.Text = "Wallet: ..."
 
 local function onUpdateDogCoins(newAmount)
-	coinLabel.Text = "DogCoins: " .. newAmount
+        walletLabel.Text = "Wallet: " .. newAmount
 end
 
 Remotes.UpdateDogCoins.OnClientEvent:Connect(onUpdateDogCoins)

--- a/src/server/AdoptionCenter.luau
+++ b/src/server/AdoptionCenter.luau
@@ -71,7 +71,7 @@ Remotes.BuyDog.OnServerInvoke = buyDog
 task.spawn(function()
     while true do
         refreshAdoptionCenter()
-        task.wait(25 * 60) -- 25 minutes
+        task.wait(60) -- 1 minute for testing
     end
 end)
 

--- a/src/server/DogManager.luau
+++ b/src/server/DogManager.luau
@@ -49,7 +49,7 @@ Remotes.CompleteDogRequest.OnServerInvoke = completeRequest
 local function setupDogRequestLoop(player)
     task.spawn(function()
         while player:IsDescendantOf(Players) do
-            task.wait(math.random(60, 300)) -- Every 1-5 minutes
+            task.wait(math.random(30, 60)) -- Every 30-60 seconds for testing
             local playerData = PlayerManager.getPlayerState(player)
             if playerData and #playerData.Dogs > 0 then
                 local randomDogIndex = math.random(1, #playerData.Dogs)

--- a/src/server/DogModelManager.luau
+++ b/src/server/DogModelManager.luau
@@ -7,11 +7,18 @@ local Remotes = require(ReplicatedStorage.Shared.Remotes)
 local DogModelManager = {}
 
 local dogModels = {}
+local dogUniqueIDs = {
+    "1ac654213aa2686d08a8495700003cb1",
+    "1ac654213aa2686d08a8495700003d3d",
+    "1ac654213aa2686d08a8495700003ec7",
+    "1ac654213aa2686d08a8495700003f40",
+}
 
 local function createDogModel(player, dogName)
     local model = Instance.new("Model")
     model.Name = dogName
     model.Parent = Workspace
+    model:SetAttribute("uniqueID", dogUniqueIDs[math.random(1, #dogUniqueIDs)])
 
     local part = Instance.new("Part")
     part.Size = Vector3.new(2, 2, 3)
@@ -40,6 +47,37 @@ local function createDogModel(player, dogName)
             task.wait(0.5)
         end
     end)
+
+    return model
+end
+
+local function createStrayDogModel(dogName)
+    local model = Instance.new("Model")
+    model.Name = dogName
+    model.Parent = Workspace
+    model:SetAttribute("uniqueID", dogUniqueIDs[math.random(1, #dogUniqueIDs)])
+
+    local part = Instance.new("Part")
+    part.Size = Vector3.new(2, 2, 3)
+    part.Color = Color3.new(math.random(), math.random(), math.random())
+    part.Anchored = false
+    part.CanCollide = true
+    part.Parent = model
+
+    local humanoid = Instance.new("Humanoid")
+    humanoid.Parent = model
+
+    model:SetPrimaryPartCFrame(CFrame.new(math.random(-50,50), 5, math.random(-50,50)))
+
+    task.spawn(function()
+        while model.Parent do
+            local randomTarget = model.PrimaryPart.Position + Vector3.new(math.random(-20,20), 0, math.random(-20,20))
+            humanoid:MoveTo(randomTarget)
+            task.wait(5)
+        end
+    end)
+
+    return model
 end
 
 local function onNewDog(player, dogName, allDogs)
@@ -67,6 +105,10 @@ Players.PlayerRemoving:Connect(onPlayerRemoving)
 
 function DogModelManager.CreateDogForPlayer(player, dogName)
     createDogModel(player, dogName)
+end
+
+function DogModelManager.CreateStrayDog(dogName)
+    return createStrayDogModel(dogName)
 end
 
 return DogModelManager

--- a/src/server/PlayerManager.luau
+++ b/src/server/PlayerManager.luau
@@ -36,7 +36,7 @@ for _, player in ipairs(Players:GetPlayers()) do
 end
 
 task.spawn(function()
-    while task.wait(180) do
+    while task.wait(60) do
         for player, data in pairs(playerData) do
             data.DogCoins = data.DogCoins + 500
             print("Gave 500 DogCoins to " .. player.Name .. ". New balance: " .. data.DogCoins)

--- a/src/server/SnackMachine.luau
+++ b/src/server/SnackMachine.luau
@@ -10,6 +10,7 @@ local DogModelManager = require(script.Parent.DogModelManager)
 local SnackMachine = {}
 
 local snackMachineModel = Workspace.GameBuildings.SnackMachine
+snackMachineModel:SetAttribute("uniqueID", "1ac654213aa2686d08a84957000039b7")
 
 local function getDogByRarity(rarity)
     local dogsOfRarity = {}

--- a/src/server/StrayDogSpawner.luau
+++ b/src/server/StrayDogSpawner.luau
@@ -1,0 +1,19 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local DogModelManager = require(script.Parent.DogModelManager)
+local DogSettings = require(ReplicatedStorage.Shared.DogSettings)
+
+local StrayDogSpawner = {}
+
+local function getRandomDogName()
+    local names = {}
+    for name in pairs(DogSettings.Dogs) do
+        table.insert(names, name)
+    end
+    return names[math.random(1, #names)]
+end
+
+for _ = 1, 3 do
+    DogModelManager.CreateStrayDog(getRandomDogName())
+end
+
+return StrayDogSpawner

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -4,5 +4,6 @@ require(script.Parent.AdoptionCenter)
 require(script.Parent.DogManager)
 require(script.Parent.PremiumShop)
 require(script.Parent.DogModelManager)
+require(script.Parent.StrayDogSpawner)
 
 print("Hello world, from server!")

--- a/src/shared/DogSettings.luau
+++ b/src/shared/DogSettings.luau
@@ -5,13 +5,19 @@ DogSettings.Dogs = {
     ["Labrador"] = { Rarity = "Common", Price = 500, Currency = "DogCoins" },
     ["Beagle"] = { Rarity = "Common", Price = 600, Currency = "DogCoins" },
     ["Poodle"] = { Rarity = "Common", Price = 700, Currency = "DogCoins" },
+    ["Chihuahua"] = { Rarity = "Common", Price = 400, Currency = "DogCoins" },
+    ["Corgi"] = { Rarity = "Common", Price = 800, Currency = "DogCoins" },
+    ["Dalmatian"] = { Rarity = "Common", Price = 900, Currency = "DogCoins" },
 
     -- 稀有犬 (用Dog币购买)
     ["ShibaInu"] = { Rarity = "Rare", Price = 2500, Currency = "DogCoins" },
     ["GoldenRetriever"] = { Rarity = "Rare", Price = 3000, Currency = "DogCoins" },
+    ["Husky"] = { Rarity = "Rare", Price = 3200, Currency = "DogCoins" },
+    ["GermanShepherd"] = { Rarity = "Rare", Price = 3500, Currency = "DogCoins" },
 
     -- 超稀有犬 (用Dog币购买)
     ["Doberman"] = { Rarity = "SuperRare", Price = 10000, Currency = "DogCoins" },
+    ["GreatDane"] = { Rarity = "SuperRare", Price = 12000, Currency = "DogCoins" },
 
     -- 限量版 (用Robux购买)
     ["RoboDog"] = { Rarity = "Limited", Price = 100, Currency = "Robux", ProductId = 0000001 },


### PR DESCRIPTION
## Summary
- expand dog breed list with small breeds and super rares
- spawn stray dogs that wander the world
- shorten coin payouts, adoption restock and dog request timers to 1 minute for testing
- display the player's DogCoin wallet on screen
- tag adoption UI, snack machine, dog models and coin wallet with unique IDs for asset tracking

## Testing
- `cargo install rojo --version 7.5.1` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `rojo build -o tmp.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896b347c7a4832186ea4619af8840a4