### PR TITLE
Assign PrimaryPart to dog models

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dog World is a pet simulation game where players can adopt, collect, and care fo
   - **Adoption Center:** A center that restocks with 10 new dogs every minute (testing) available for purchase with DogCoins. *(UI Unique ID: 1ac654213aa2686d08a849570000224d)*
   - **Premium Shop:** A special shop to purchase limited edition dogs with Robux.
 - **Stray Dogs:** Various stray dogs wander the world and can be found roaming around.
-- **Dog Models:** All dog models are tagged with unique IDs for asset tracking (1ac654213aa2686d08a8495700003cb1, 1ac654213aa2686d08a8495700003d3d, 1ac654213aa2686d08a8495700003ec7, 1ac654213aa2686d08a8495700003f40).
+- **Dog Models:** All dog models are tagged with unique IDs for asset tracking (1ac654213aa2686d08a8495700003cb1, 1ac654213aa2686d08a8495700003d3d, 1ac654213aa2686d08a8495700003ec7, 1ac654213aa2686d08a8495700003f40) and define a `PrimaryPart` for positioning.
 - **Economy System:**
   - **DogCoins:** The primary in-game currency. Players automatically receive 500 DogCoins every minute (testing).
   - **Robux:** Used for purchasing exclusive, limited-edition dogs.
@@ -38,6 +38,7 @@ All core gameplay features have been implemented. The next step is to replace th
 - Corrected `DogModelManager` to use `OnServerEvent` instead of `OnClientEvent`, resolving the server-side event error.
 - Fixed building component positions by assigning explicit CFrames, preventing structures from spawning below the ground level.
 - Renamed bootstrap scripts so server and client modules load correctly at runtime, resolving missing `PlayerManager` and `CoinDisplay` errors.
+- Assigned a `PrimaryPart` to every dog model, ensuring `SetPrimaryPartCFrame` works without errors.
 
 
 ## Getting Started

--- a/src/server/DogModelManager.luau
+++ b/src/server/DogModelManager.luau
@@ -26,6 +26,7 @@ local function createDogModel(player, dogName)
     part.Anchored = false
     part.CanCollide = true
     part.Parent = model
+    model.PrimaryPart = part
 
     local humanoid = Instance.new("Humanoid")
     humanoid.Parent = model
@@ -63,6 +64,7 @@ local function createStrayDogModel(dogName)
     part.Anchored = false
     part.CanCollide = true
     part.Parent = model
+    model.PrimaryPart = part
 
     local humanoid = Instance.new("Humanoid")
     humanoid.Parent = model


### PR DESCRIPTION
## Summary
- assign newly created parts as the model `PrimaryPart` in dog factories
- ensure `SetPrimaryPartCFrame` runs after `PrimaryPart` assignment
- document primary part assignment in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c1638c78832186e74853a1b5cf4d