### PR TITLE
Ensure SnackMachine primary part is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ All core gameplay features have been implemented. The next step is to replace th
 - Fixed building component positions by assigning explicit CFrames, preventing structures from spawning below the ground level.
 - Renamed bootstrap scripts so server and client modules load correctly at runtime, resolving missing `PlayerManager` and `CoinDisplay` errors.
 
+### Building Models
+
+- Ensure every building model has its `PrimaryPart` set (usually to the main `Body` part). Scripts rely on this to position models with `SetPrimaryPartCFrame`.
 
 ## Getting Started
 To build the place from scratch, use:

--- a/src/buildings/SnackMachine.rbxmx
+++ b/src/buildings/SnackMachine.rbxmx
@@ -1,8 +1,9 @@
 <roblox xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
-	<Item class="Model" referent="RBX0">
-		<Properties>
-			<string name="Name">SnackMachine</string>
-		</Properties>
+        <Item class="Model" referent="RBX0">
+                <Properties>
+                        <string name="Name">SnackMachine</string>
+                        <Object name="PrimaryPart">RBX1</Object>
+                </Properties>
                 <Item class="Part" referent="RBX1">
                         <Properties>
                                 <string name="Name">Body</string>

--- a/src/server/SnackMachine.luau
+++ b/src/server/SnackMachine.luau
@@ -53,11 +53,15 @@ local function setupMachineForPlayer(player)
     machineClone.Name = player.Name .. "'s Snack Machine"
     machineClone.Parent = Workspace
 
-    if player.Character then
+    machineClone.PrimaryPart = machineClone:FindFirstChild("Body")
+
+    if player.Character and machineClone.PrimaryPart then
         machineClone:SetPrimaryPartCFrame(player.Character:GetPrimaryPartCFrame() + Vector3.new(5, 0, 5))
     end
     player.CharacterAdded:Connect(function(character)
-        machineClone:SetPrimaryPartCFrame(character:GetPrimaryPartCFrame() + Vector3.new(5, 0, 5))
+        if machineClone.PrimaryPart then
+            machineClone:SetPrimaryPartCFrame(character:GetPrimaryPartCFrame() + Vector3.new(5, 0, 5))
+        end
     end)
 
     task.spawn(function()


### PR DESCRIPTION
## Summary
- Assign SnackMachine model's PrimaryPart to the Body part
- Set cloned SnackMachine's PrimaryPart before positioning
- Document PrimaryPart requirement for building models

## Testing
- `rojo --version` *(command not found)*
- `curl -fsSL https://raw.githubusercontent.com/LPGhatguy/aftman/main/install.sh | bash -s -- -y` *(403 error)*
- `cargo install rojo` *(network 403 error)*

------
https://chatgpt.com/codex/tasks/task_e_6896c15a12b88321abea2c07fbea3d3a