### PR TITLE
Refactor GUI loading to avoid invalid asset IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ Dog World is a pet simulation game where players can adopt, collect, and care fo
 ### Core Features
 
 - **Pet Adoption:** Adopt dogs through different methods:
-  - **Snack Machine:** An automatic machine that attracts stray dogs every 10 seconds. *(Unique ID: 1ac654213aa2686d08a84957000039b7)*
-  - **Adoption Center:** A center that restocks with 10 new dogs every minute (testing) available for purchase with DogCoins. *(UI Unique ID: 1ac654213aa2686d08a849570000224d)*
-  - **Premium Shop:** A special shop to purchase limited edition dogs with Robux.
+- **Snack Machine:** An automatic machine that attracts stray dogs every 10 seconds.
+- **Adoption Center:** A center that restocks with 10 new dogs every minute (testing) available for purchase with DogCoins.
+- **Premium Shop:** A special shop to purchase limited edition dogs with Robux.
 - **Stray Dogs:** Various stray dogs wander the world and can be found roaming around.
 - **Dog Models:** All dog models are tagged with unique IDs for asset tracking (1ac654213aa2686d08a8495700003cb1, 1ac654213aa2686d08a8495700003d3d, 1ac654213aa2686d08a8495700003ec7, 1ac654213aa2686d08a8495700003f40) and define a `PrimaryPart` for positioning.
 - **Economy System:**
   - **DogCoins:** The primary in-game currency. Players automatically receive 500 DogCoins every minute (testing).
   - **Robux:** Used for purchasing exclusive, limited-edition dogs.
-  - **Wallet Display:** The player's current DogCoin balance is always visible on screen. *(Unique ID: 1ac654213aa2686d08a8495700003bcb)*
+- **Wallet Display:** The player's current DogCoin balance is always visible on screen.
 - **Dog Requests:** Your dogs will occasionally have requests (e.g., playing, eating). Fulfilling these requests rewards you with DogCoins. During testing, these occur every 30–60 seconds.
 
 ## Current Status
@@ -31,7 +31,7 @@ All core gameplay features have been implemented. The next step is to replace th
 - Reordered the `CFrame` elements in `src/buildings/AdoptionCenter.rbxmx` so that position fields precede rotation components, resolving the malformed XML error that prevented `rojo serve` from running.
 - Added roaming stray dogs and expanded the list of available breeds.
 - Shortened in-game timers to one minute for faster testing.
-- Tagged the adoption UI, pet snack machine, DogCoin wallet, and dog models with unique IDs for asset tracking.
+- Tagged the pet snack machine and dog models with unique IDs for asset tracking.
 - Added an asset loader to retrieve UI components from the asset library by their unique IDs.
 - Reworked the asset loader to load IDs on the server with `InsertService` or on the client via `require`, eliminating `GetObjects` permission errors.
 - Updated client scripts to return a value so they can be required without runtime failures.
@@ -39,6 +39,11 @@ All core gameplay features have been implemented. The next step is to replace th
 - Fixed building component positions by assigning explicit CFrames, preventing structures from spawning below the ground level.
 - Renamed bootstrap scripts so server and client modules load correctly at runtime, resolving missing `PlayerManager` and `CoinDisplay` errors.
 - Assigned a `PrimaryPart` to every dog model, ensuring `SetPrimaryPartCFrame` works without errors.
+- Replaced non-numeric GUI asset IDs with direct GUI construction; `AssetLoader.loadGui` now requires valid numeric asset IDs.
+
+### Asset ID Requirements
+
+Any use of `AssetLoader.loadGui` must provide a valid numeric Roblox asset ID. Placeholder strings or GUIDs are no longer supported. If a numeric ID is unavailable, create the GUI elements directly in code.
 
 ### Building Models
 

--- a/src/client/AdoptionCenterGui.luau
+++ b/src/client/AdoptionCenterGui.luau
@@ -3,19 +3,14 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Remotes = require(ReplicatedStorage.Shared.Remotes)
 local DogSettings = require(ReplicatedStorage.Shared.DogSettings)
-local AssetLoader = require(ReplicatedStorage.Shared.AssetLoader)
 
 local player = Players.LocalPlayer
 local playerGui = player:WaitForChild("PlayerGui")
 
 -- Main GUI
-local screenGui = AssetLoader.loadGui("1ac654213aa2686d08a849570000224d", playerGui)
-if not screenGui then
-    screenGui = Instance.new("ScreenGui")
-    screenGui.Name = "AdoptionCenterGui"
-    screenGui.Parent = playerGui
-end
-screenGui:SetAttribute("uniqueID", "1ac654213aa2686d08a849570000224d")
+local screenGui = Instance.new("ScreenGui")
+screenGui.Name = "AdoptionCenterGui"
+screenGui.Parent = playerGui
 
 -- Adoption Center UI
 local mainFrame = screenGui:FindFirstChild("AdoptionCenterFrame")

--- a/src/client/CoinDisplay.luau
+++ b/src/client/CoinDisplay.luau
@@ -2,36 +2,29 @@ local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Remotes = require(ReplicatedStorage.Shared.Remotes)
-local AssetLoader = require(ReplicatedStorage.Shared.AssetLoader)
 
 local player = Players.LocalPlayer
 
 local playerGui = player:WaitForChild("PlayerGui")
 
-local screenGui = AssetLoader.loadGui("1ac654213aa2686d08a8495700003bcb", playerGui)
-if not screenGui then
-    screenGui = Instance.new("ScreenGui")
-    screenGui.Name = "WalletGui"
-    screenGui.Parent = playerGui
-end
-screenGui:SetAttribute("uniqueID", "1ac654213aa2686d08a8495700003bcb")
+local screenGui = Instance.new("ScreenGui")
+screenGui.Name = "WalletGui"
+screenGui.Parent = playerGui
 
-local walletLabel = screenGui:FindFirstChild("WalletLabel")
-if not walletLabel then
-    walletLabel = Instance.new("TextLabel", screenGui)
-    walletLabel.Name = "WalletLabel"
-    walletLabel.Size = UDim2.new(0, 200, 0, 50)
-    walletLabel.Position = UDim2.new(0, 10, 0, 10)
-    walletLabel.BackgroundColor3 = Color3.new(0, 0, 0)
-    walletLabel.BackgroundTransparency = 0.5
-    walletLabel.TextColor3 = Color3.new(1, 1, 1)
-    walletLabel.Font = Enum.Font.SourceSansBold
-    walletLabel.TextSize = 24
-    walletLabel.Text = "Wallet: ..."
-end
+local walletLabel = Instance.new("TextLabel")
+walletLabel.Name = "WalletLabel"
+walletLabel.Size = UDim2.new(0, 200, 0, 50)
+walletLabel.Position = UDim2.new(0, 10, 0, 10)
+walletLabel.BackgroundColor3 = Color3.new(0, 0, 0)
+walletLabel.BackgroundTransparency = 0.5
+walletLabel.TextColor3 = Color3.new(1, 1, 1)
+walletLabel.Font = Enum.Font.SourceSansBold
+walletLabel.TextSize = 24
+walletLabel.Text = "Wallet: ..."
+walletLabel.Parent = screenGui
 
 local function onUpdateDogCoins(newAmount)
-        walletLabel.Text = "Wallet: " .. newAmount
+    walletLabel.Text = "Wallet: " .. newAmount
 end
 
 Remotes.UpdateDogCoins.OnClientEvent:Connect(onUpdateDogCoins)


### PR DESCRIPTION
## Summary
- Build wallet display and adoption center UIs directly instead of using `AssetLoader.loadGui`
- Document numeric asset ID requirement for `AssetLoader.loadGui`

## Testing
- `rojo --version` *(command not found)*
- `cargo install rojo` *(failed: download of config.json failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896cadb3e508321b3dc54828087d548