### PR TITLE
feat: set HumanoidRootPart as dog primary part

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dog World is a pet simulation game where players can adopt, collect, and care fo
   - **Adoption Center:** A center that restocks with 10 new dogs every minute (testing) available for purchase with DogCoins. *(UI Unique ID: 1ac654213aa2686d08a849570000224d)*
   - **Premium Shop:** A special shop to purchase limited edition dogs with Robux.
 - **Stray Dogs:** Various stray dogs wander the world and can be found roaming around.
-- **Dog Models:** All dog models are tagged with unique IDs for asset tracking (1ac654213aa2686d08a8495700003cb1, 1ac654213aa2686d08a8495700003d3d, 1ac654213aa2686d08a8495700003ec7, 1ac654213aa2686d08a8495700003f40) and define a `PrimaryPart` for positioning.
+- **Dog Models:** All dog models are tagged with unique IDs for asset tracking (1ac654213aa2686d08a8495700003cb1, 1ac654213aa2686d08a8495700003d3d, 1ac654213aa2686d08a8495700003ec7, 1ac654213aa2686d08a8495700003f40) and require a `HumanoidRootPart` set as the `PrimaryPart` for positioning and movement.
 - **Economy System:**
   - **DogCoins:** The primary in-game currency. Players automatically receive 500 DogCoins every minute (testing).
   - **Robux:** Used for purchasing exclusive, limited-edition dogs.
@@ -39,6 +39,7 @@ All core gameplay features have been implemented. The next step is to replace th
 - Fixed building component positions by assigning explicit CFrames, preventing structures from spawning below the ground level.
 - Renamed bootstrap scripts so server and client modules load correctly at runtime, resolving missing `PlayerManager` and `CoinDisplay` errors.
 - Assigned a `PrimaryPart` to every dog model, ensuring `SetPrimaryPartCFrame` works without errors.
+- Ensured dog models use a `HumanoidRootPart` as their `PrimaryPart` so they can be positioned and moved correctly.
 
 ### Building Models
 

--- a/src/server/DogModelManager.luau
+++ b/src/server/DogModelManager.luau
@@ -21,6 +21,7 @@ local function createDogModel(player, dogName)
     model:SetAttribute("uniqueID", dogUniqueIDs[math.random(1, #dogUniqueIDs)])
 
     local part = Instance.new("Part")
+    part.Name = "HumanoidRootPart"
     part.Size = Vector3.new(2, 2, 3)
     part.Color = Color3.new(math.random(), math.random(), math.random())
     part.Anchored = false
@@ -29,6 +30,7 @@ local function createDogModel(player, dogName)
     model.PrimaryPart = part
 
     local humanoid = Instance.new("Humanoid")
+    humanoid.RootPart = part
     humanoid.Parent = model
 
     model:SetPrimaryPartCFrame(player.Character.PrimaryPart.CFrame + Vector3.new(3, 0, 3))
@@ -59,6 +61,7 @@ local function createStrayDogModel(dogName)
     model:SetAttribute("uniqueID", dogUniqueIDs[math.random(1, #dogUniqueIDs)])
 
     local part = Instance.new("Part")
+    part.Name = "HumanoidRootPart"
     part.Size = Vector3.new(2, 2, 3)
     part.Color = Color3.new(math.random(), math.random(), math.random())
     part.Anchored = false
@@ -67,14 +70,18 @@ local function createStrayDogModel(dogName)
     model.PrimaryPart = part
 
     local humanoid = Instance.new("Humanoid")
+    humanoid.RootPart = part
     humanoid.Parent = model
 
     model:SetPrimaryPartCFrame(CFrame.new(math.random(-50,50), 5, math.random(-50,50)))
 
     task.spawn(function()
         while model.Parent do
-            local randomTarget = model.PrimaryPart.Position + Vector3.new(math.random(-20,20), 0, math.random(-20,20))
-            humanoid:MoveTo(randomTarget)
+            local primaryPart = model.PrimaryPart
+            if primaryPart then
+                local randomTarget = primaryPart.Position + Vector3.new(math.random(-20,20), 0, math.random(-20,20))
+                humanoid:MoveTo(randomTarget)
+            end
             task.wait(5)
         end
     end)


### PR DESCRIPTION
## Summary
- name dog parts `HumanoidRootPart` and use them as humanoid roots
- guard stray dog movement against missing `PrimaryPart`
- document requirement for a `HumanoidRootPart` primary part

## Testing
- `rojo build -o test.rbxlx` *(fails: command not found)*
- `cargo install rojo --version 7.5.1` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896cb001e008321b32f6b408eecdc7c