### PR TITLE
Implement GUID-based dog IDs and use IDs for dog requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Dog World is a pet simulation game where players can adopt, collect, and care fo
   - **Premium Shop:** A special shop to purchase limited edition dogs with Robux.
 - **Stray Dogs:** Various stray dogs wander the world and can be found roaming around.
 - **Dog Models:** All dog models are tagged with unique IDs for asset tracking (1ac654213aa2686d08a8495700003cb1, 1ac654213aa2686d08a8495700003d3d, 1ac654213aa2686d08a8495700003ec7, 1ac654213aa2686d08a8495700003f40) and define a `PrimaryPart` for positioning.
+- **Dog IDs:** Each adopted dog now receives a unique GUID and is stored as a table `{Id, Name, Request}`. Client interfaces display these IDs and use them for request completion.
 - **Economy System:**
   - **DogCoins:** The primary in-game currency. Players automatically receive 500 DogCoins every minute (testing).
   - **Robux:** Used for purchasing exclusive, limited-edition dogs.
@@ -39,6 +40,9 @@ All core gameplay features have been implemented. The next step is to replace th
 - Fixed building component positions by assigning explicit CFrames, preventing structures from spawning below the ground level.
 - Renamed bootstrap scripts so server and client modules load correctly at runtime, resolving missing `PlayerManager` and `CoinDisplay` errors.
 - Assigned a `PrimaryPart` to every dog model, ensuring `SetPrimaryPartCFrame` works without errors.
+- Named the dog models' primary part `HumanoidRootPart` so humanoids have a valid root part and modules load without errors.
+- Parent dog models to the workspace only after their parts and humanoid are added.
+- Assign the models' `PrimaryPart` once parented to avoid read-only `RootPart` assignment errors.
 
 ### Building Models
 

--- a/src/client/DogInteractionGui.luau
+++ b/src/client/DogInteractionGui.luau
@@ -8,10 +8,10 @@ local playerGui = player:WaitForChild("PlayerGui")
 
 local inventoryFrame = playerGui:WaitForChild("DogInventoryGui"):WaitForChild("InventoryFrame")
 
-local function completeRequest(dogName)
-    local success = Remotes.CompleteDogRequest:InvokeServer(dogName)
+local function completeRequest(dogId)
+    local success = Remotes.CompleteDogRequest:InvokeServer(dogId)
     if success then
-        print("Request completed for " .. dogName)
+        print("Request completed for dog " .. dogId)
     end
 end
 
@@ -22,23 +22,20 @@ local function updateDogListWithRequests(dogs)
         end
     end
 
-    for _, dogData in ipairs(dogs) do
-        local dogName = type(dogData) == "string" and dogData or dogData.Name
-        local request = type(dogData) == "table" and dogData.Request or nil
-
+    for _, dog in ipairs(dogs) do
         local itemFrame = Instance.new("Frame", inventoryFrame)
         itemFrame.Size = UDim2.new(1, 0, 0, 60)
 
         local nameLabel = Instance.new("TextLabel", itemFrame)
         nameLabel.Size = UDim2.new(1, 0, 0.5, 0)
-        nameLabel.Text = dogName
+        nameLabel.Text = dog.Name .. " (" .. dog.Id .. ")"
         nameLabel.TextColor3 = Color3.new(1,1,1)
 
-        if request then
+        if dog.Request then
             local requestLabel = Instance.new("TextLabel", itemFrame)
             requestLabel.Size = UDim2.new(0.7, 0, 0.5, 0)
             requestLabel.Position = UDim2.new(0, 0, 0.5, 0)
-            requestLabel.Text = "Wants to: " .. request
+            requestLabel.Text = "Wants to: " .. dog.Request
             requestLabel.TextColor3 = Color3.new(1,1,0)
 
             local completeButton = Instance.new("TextButton", itemFrame)
@@ -46,7 +43,7 @@ local function updateDogListWithRequests(dogs)
             completeButton.Position = UDim2.new(0.7, 0, 0.5, 0)
             completeButton.Text = "Complete"
             completeButton.MouseButton1Click:Connect(function()
-                completeRequest(dogName)
+                completeRequest(dog.Id)
             end)
         end
     end

--- a/src/client/DogInventory.luau
+++ b/src/client/DogInventory.luau
@@ -63,17 +63,17 @@ local function updateDogList(dogs)
         end
     end
 
-    for _, dogName in ipairs(dogs) do
+    for _, dog in ipairs(dogs) do
         local dogLabel = Instance.new("TextLabel", inventoryFrame)
-        dogLabel.Text = dogName
+        dogLabel.Text = dog.Name .. " (" .. dog.Id .. ")"
         dogLabel.Size = UDim2.new(1, -10, 0, 30)
         dogLabel.TextColor3 = Color3.new(1, 1, 1)
     end
 end
 
-local function onNewDog(dogName, allDogs)
+local function onNewDog(dog, allDogs)
     -- Show alert
-    alertLabel.Text = "You got a new dog: " .. dogName .. "!"
+    alertLabel.Text = "You got a new dog: " .. dog.Name .. " (" .. dog.Id .. ")!"
     alertFrame.Visible = true
     task.wait(3)
     alertFrame.Visible = false

--- a/src/server/AdoptionCenter.luau
+++ b/src/server/AdoptionCenter.luau
@@ -43,7 +43,10 @@ local function buyDog(player, dogName)
     end
 
     playerData.DogCoins = playerData.DogCoins - dogInfo.Price
-    table.insert(player.Character and playerData.Dogs or {}, dogName)
+
+    local dogId = DogModelManager.CreateDogForPlayer(player, dogName)
+    local newDog = { Id = dogId, Name = dogName, Request = nil }
+    table.insert(playerData.Dogs, newDog)
 
     -- Remove dog from adoption center
     for i, name in ipairs(availableDogs) do
@@ -54,8 +57,7 @@ local function buyDog(player, dogName)
     end
 
     Remotes.UpdateDogCoins:FireClient(player, playerData.DogCoins)
-    Remotes.NewDogAlert:FireClient(player, dogName, playerData.Dogs)
-    DogModelManager.CreateDogForPlayer(player, dogName)
+    Remotes.NewDogAlert:FireClient(player, newDog, playerData.Dogs)
     Remotes.AdoptionCenterRestocked:FireAllClients(availableDogs) -- Update for all clients
 
     print(player.Name .. " bought a " .. dogName)

--- a/src/server/DogManager.luau
+++ b/src/server/DogManager.luau
@@ -11,15 +11,15 @@ local dogRequests = {
     "Drinking", "Walking", "Watching TV", "Socializing"
 }
 
-local function giveRandomRequest(player, dogName)
+local function giveRandomRequest(player, dogId)
     local request = dogRequests[math.random(1, #dogRequests)]
     local playerData = PlayerManager.getPlayerState(player)
-    
+
     if playerData then
-        for i, dog in ipairs(playerData.Dogs) do
-            if (type(dog) == "string" and dog == dogName) or (type(dog) == "table" and dog.Name == dogName) then
-                playerData.Dogs[i] = { Name = dogName, Request = request }
-                print(player.Name .. "'s dog " .. dogName .. " wants to go " .. request)
+        for _, dog in ipairs(playerData.Dogs) do
+            if dog.Id == dogId and not dog.Request then
+                dog.Request = request
+                print(player.Name .. "'s dog " .. dog.Name .. " wants to go " .. request)
                 Remotes.DogRequestUpdate:FireClient(player, playerData.Dogs)
                 return
             end
@@ -27,16 +27,16 @@ local function giveRandomRequest(player, dogName)
     end
 end
 
-local function completeRequest(player, dogName)
+local function completeRequest(player, dogId)
     local playerData = PlayerManager.getPlayerState(player)
     if playerData then
-        for i, dogData in ipairs(playerData.Dogs) do
-            if dogData.Name == dogName and dogData.Request then
-                playerData.Dogs[i] = dogData.Name -- Reset to string
+        for _, dog in ipairs(playerData.Dogs) do
+            if dog.Id == dogId and dog.Request then
+                dog.Request = nil
                 playerData.DogCoins = playerData.DogCoins + 200
                 Remotes.UpdateDogCoins:FireClient(player, playerData.DogCoins)
                 Remotes.DogRequestUpdate:FireClient(player, playerData.Dogs)
-                print(player.Name .. " completed " .. dogName .. "'s request.")
+                print(player.Name .. " completed " .. dog.Name .. "'s request.")
                 return true
             end
         end
@@ -52,18 +52,10 @@ local function setupDogRequestLoop(player)
             task.wait(math.random(30, 60)) -- Every 30-60 seconds for testing
             local playerData = PlayerManager.getPlayerState(player)
             if playerData and #playerData.Dogs > 0 then
-                local randomDogIndex = math.random(1, #playerData.Dogs)
-                local dog = playerData.Dogs[randomDogIndex]
-                
-                local dogName
-                if type(dog) == "string" then
-                    dogName = dog
-                elseif type(dog) == "table" and not dog.Request then
-                    dogName = dog.Name
-                end
+                local randomDog = playerData.Dogs[math.random(1, #playerData.Dogs)]
 
-                if dogName then
-                    giveRandomRequest(player, dogName)
+                if randomDog and not randomDog.Request then
+                    giveRandomRequest(player, randomDog.Id)
                 end
             end
         end

--- a/src/server/DogModelManager.luau
+++ b/src/server/DogModelManager.luau
@@ -1,37 +1,36 @@
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Workspace = game:GetService("Workspace")
-
-local Remotes = require(ReplicatedStorage.Shared.Remotes)
+local HttpService = game:GetService("HttpService")
 
 local DogModelManager = {}
 
 local dogModels = {}
-local dogUniqueIDs = {
-    "1ac654213aa2686d08a8495700003cb1",
-    "1ac654213aa2686d08a8495700003d3d",
-    "1ac654213aa2686d08a8495700003ec7",
-    "1ac654213aa2686d08a8495700003f40",
-}
 
-local function createDogModel(player, dogName)
+local function createDogModel(player, dogName, dogId)
     local model = Instance.new("Model")
     model.Name = dogName
-    model.Parent = Workspace
-    model:SetAttribute("uniqueID", dogUniqueIDs[math.random(1, #dogUniqueIDs)])
+
+    dogId = dogId or HttpService:GenerateGUID(false)
+    model:SetAttribute("uniqueID", dogId)
 
     local part = Instance.new("Part")
+    part.Name = "HumanoidRootPart"
     part.Size = Vector3.new(2, 2, 3)
     part.Color = Color3.new(math.random(), math.random(), math.random())
     part.Anchored = false
     part.CanCollide = true
     part.Parent = model
-    model.PrimaryPart = part
 
     local humanoid = Instance.new("Humanoid")
     humanoid.Parent = model
 
-    model:SetPrimaryPartCFrame(player.Character.PrimaryPart.CFrame + Vector3.new(3, 0, 3))
+    model.Parent = Workspace
+    model.PrimaryPart = part
+
+    if player.Character and player.Character.PrimaryPart then
+        model:PivotTo(player.Character.PrimaryPart.CFrame + Vector3.new(3, 0, 3))
+    end
 
     if not dogModels[player] then
         dogModels[player] = {}
@@ -49,27 +48,29 @@ local function createDogModel(player, dogName)
         end
     end)
 
-    return model
+    return model, dogId
 end
 
 local function createStrayDogModel(dogName)
     local model = Instance.new("Model")
     model.Name = dogName
-    model.Parent = Workspace
-    model:SetAttribute("uniqueID", dogUniqueIDs[math.random(1, #dogUniqueIDs)])
+    model:SetAttribute("uniqueID", HttpService:GenerateGUID(false))
 
     local part = Instance.new("Part")
+    part.Name = "HumanoidRootPart"
     part.Size = Vector3.new(2, 2, 3)
     part.Color = Color3.new(math.random(), math.random(), math.random())
     part.Anchored = false
     part.CanCollide = true
     part.Parent = model
-    model.PrimaryPart = part
 
     local humanoid = Instance.new("Humanoid")
     humanoid.Parent = model
 
-    model:SetPrimaryPartCFrame(CFrame.new(math.random(-50,50), 5, math.random(-50,50)))
+    model.Parent = Workspace
+    model.PrimaryPart = part
+
+    model:PivotTo(CFrame.new(math.random(-50,50), 5, math.random(-50,50)))
 
     task.spawn(function()
         while model.Parent do
@@ -82,10 +83,6 @@ local function createStrayDogModel(dogName)
     return model
 end
 
-local function onNewDog(player, dogName, allDogs)
-    createDogModel(player, dogName)
-end
-
 local function onPlayerRemoving(player)
     if dogModels[player] then
         for _, model in ipairs(dogModels[player]) do
@@ -95,16 +92,10 @@ local function onPlayerRemoving(player)
     end
 end
 
-Remotes.NewDogAlert.OnServerEvent:Connect(onNewDog)
-
 Players.PlayerRemoving:Connect(onPlayerRemoving)
-
--- We need a server-side event to trigger dog creation.
--- Let's modify the NewDogAlert to be fired from the server to the server.
--- A better approach would be a dedicated signal module, but for now, this will work.
-
 function DogModelManager.CreateDogForPlayer(player, dogName)
-    createDogModel(player, dogName)
+    local _, id = createDogModel(player, dogName)
+    return id
 end
 
 function DogModelManager.CreateStrayDog(dogName)

--- a/src/server/PlayerManager.luau
+++ b/src/server/PlayerManager.luau
@@ -14,7 +14,7 @@ end
 local function onPlayerAdded(player)
 	playerData[player] = {
 		DogCoins = 0,
-		Dogs = {}
+		Dogs = {}, -- { Id = string, Name = string, Request = string? }
 	}
 	print(player.Name .. " has joined the game!")
 

--- a/src/server/PremiumShop.luau
+++ b/src/server/PremiumShop.luau
@@ -29,10 +29,11 @@ local function processReceipt(receiptInfo)
     end
 
     if dogName then
-        table.insert(playerData.Dogs, dogName)
+        local dogId = DogModelManager.CreateDogForPlayer(player, dogName)
+        local newDog = { Id = dogId, Name = dogName, Request = nil }
+        table.insert(playerData.Dogs, newDog)
         print(player.Name .. " has purchased a " .. dogName .. "!")
-        DogModelManager.CreateDogForPlayer(player, dogName)
-        Remotes.NewDogAlert:FireClient(player, dogName, playerData.Dogs)
+        Remotes.NewDogAlert:FireClient(player, newDog, playerData.Dogs)
         return Enum.ProductPurchaseDecision.PurchaseGranted
     else
         warn("Could not find dog with ProductId: " .. receiptInfo.ProductId)

--- a/src/server/SnackMachine.luau
+++ b/src/server/SnackMachine.luau
@@ -40,10 +40,11 @@ local function attractDog(player)
     if dogName then
         local playerData = PlayerManager.getPlayerState(player)
         if playerData and player.Character then
-            table.insert(playerData.Dogs, dogName)
+            local dogId = DogModelManager.CreateDogForPlayer(player, dogName)
+            local newDog = { Id = dogId, Name = dogName, Request = nil }
+            table.insert(playerData.Dogs, newDog)
             print(player.Name .. " has attracted a " .. dogName .. "!")
-            DogModelManager.CreateDogForPlayer(player, dogName)
-            Remotes.NewDogAlert:FireClient(player, dogName, playerData.Dogs)
+            Remotes.NewDogAlert:FireClient(player, newDog, playerData.Dogs)
         end
     end
 end


### PR DESCRIPTION
## Summary
- generate unique GUIDs for each dog model and return dog IDs
- store player dogs as `{Id, Name, Request}` and propagate IDs through adoption, premium shop, and snack machine
- update dog request system and client GUIs to display and operate on dog IDs
- assemble dog models off-workspace and parent them only after initialization to avoid read-only `RootPart` errors
- set each dog model's `PrimaryPart` after parenting to the workspace to prevent `RootPart` property assignment failures
- document new dog ID structure and model initialization order in README

## Testing
- `rojo build -o "gag_gpt5.rbxlx"` *(command not found)*
- `wget https://github.com/rojo-rbx/rojo/releases/download/v7.5.1/rojo-7.5.1-linux.zip -O /tmp/rojo.zip` *(Proxy tunneling failed: ForbiddenUnable to establish SSL connection)*

------
https://chatgpt.com/codex/tasks/task_e_6896cafbf94c8321946b862010ff9cee