### PR TITLE
Fix Humanoid root part assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ All core gameplay features have been implemented. The next step is to replace th
 
 ### Recent Fixes
 
+- Removed assignment to `Humanoid.RootPart` in `DogModelManager`, relying on `PrimaryPart` to prevent read-only property errors.
+- Simplified dog creation by setting each model's `PrimaryPart` once after parenting and removing redundant `PivotTo` calls.
 - Reordered the `CFrame` elements in `src/buildings/AdoptionCenter.rbxmx` so that position fields precede rotation components, resolving the malformed XML error that prevented `rojo serve` from running.
 - Added roaming stray dogs and expanded the list of available breeds.
 - Shortened in-game timers to one minute for faster testing.

--- a/src/server/DogModelManager.luau
+++ b/src/server/DogModelManager.luau
@@ -22,14 +22,7 @@ local function createDogModel(player, dogName, dogId)
     part.Parent = model
 
     local humanoid = Instance.new("Humanoid")
-    humanoid.RootPart = part
     humanoid.Parent = model
-    model.PrimaryPart = part
-
-    if player.Character and player.Character.PrimaryPart then
-        model:PivotTo(player.Character.PrimaryPart.CFrame + Vector3.new(3, 0, 3))
-    end
-
     model.Parent = Workspace
     model.PrimaryPart = part
 
@@ -70,12 +63,7 @@ local function createStrayDogModel(dogName)
     part.Parent = model
 
     local humanoid = Instance.new("Humanoid")
-    humanoid.RootPart = part
     humanoid.Parent = model
-    model.PrimaryPart = part
-
-    model:PivotTo(CFrame.new(math.random(-50,50), 5, math.random(-50,50)))
-
     model.Parent = Workspace
     model.PrimaryPart = part
 


### PR DESCRIPTION
## Summary
- avoid assigning to Humanoid.RootPart in dog model creation
- simplify dog creation by setting PrimaryPart once after parenting and removing redundant PivotTo calls
- document fix in README

## Testing
- `rojo --version` *(fails: command not found)*
- `cargo install rojo --version 7.5.1` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `cargo install aftman` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `rojo build -o "gag_gpt5.rbxlx"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896d8f0ffa483219849c8cdc67961c2