### PR TITLE
Fix dog request completion and adjust adoption mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ All core gameplay features have been implemented. The next step is to replace th
 
 ### Recent Fixes
 
+- Fixed `CompleteDogRequest` invocation in `DogInteractionGui` to prevent nil reference errors.
+- Reduced snack machine dog adoption chance to 20%.
+- Dogs now follow their owners while keeping a short distance to avoid overlap.
 - Removed assignment to `Humanoid.RootPart` in `DogModelManager`, relying on `PrimaryPart` to prevent read-only property errors.
 - Simplified dog creation by setting each model's `PrimaryPart` once after parenting and removing redundant `PivotTo` calls.
 - Reordered the `CFrame` elements in `src/buildings/AdoptionCenter.rbxmx` so that position fields precede rotation components, resolving the malformed XML error that prevented `rojo serve` from running.

--- a/src/client/DogInteractionGui.luau
+++ b/src/client/DogInteractionGui.luau
@@ -11,7 +11,7 @@ local playerGui = player:WaitForChild("PlayerGui")
 local inventoryFrame = playerGui:WaitForChild("DogInventoryGui"):WaitForChild("InventoryFrame")
 
 local function completeRequest(dogId)
-    local success = Remotes.CompleteDogRequest:InvokeServer(dogId)
+    local success = CompleteDogRequest:InvokeServer(dogId)
     if success then
         print("Request completed for dog " .. dogId)
     end

--- a/src/server/DogModelManager.luau
+++ b/src/server/DogModelManager.luau
@@ -39,7 +39,8 @@ local function createDogModel(player, dogName, dogId)
     task.spawn(function()
         while model.Parent do
             if player.Character and player.Character:FindFirstChild("HumanoidRootPart") then
-                local targetPosition = player.Character.HumanoidRootPart.Position
+                local rootPart = player.Character.HumanoidRootPart
+                local targetPosition = rootPart.Position - rootPart.CFrame.LookVector * 5
                 humanoid:MoveTo(targetPosition)
             end
             task.wait(0.5)

--- a/src/server/SnackMachine.luau
+++ b/src/server/SnackMachine.luau
@@ -29,11 +29,11 @@ local function attractDog(player)
     local chance = math.random()
 
     local dogName
-    if chance <= 0.05 then -- 5% chance for SuperRare
+    if chance <= 0.01 then -- 1% chance for SuperRare
         dogName = getDogByRarity("SuperRare")
-    elseif chance <= 0.20 then -- 15% chance for Rare (20% - 5%)
+    elseif chance <= 0.05 then -- 4% chance for Rare (5% - 1%)
         dogName = getDogByRarity("Rare")
-    elseif chance <= 0.80 then -- 60% chance for Common (80% - 20%)
+    elseif chance <= 0.20 then -- 15% chance for Common (20% - 5%)
         dogName = getDogByRarity("Common")
     end
 


### PR DESCRIPTION
## Summary
- Fix nil reference in dog request completion GUI
- Lower snack machine adoption rate to 20%
- Make follower dogs keep their distance

## Testing
- `rojo build -o test.rbxlx` *(fails: command not found)*
- `npx rojo --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896dcdb896c8321b867c684521ddcb7