### PR TITLE
Load assets on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All core gameplay features have been implemented. The next step is to replace th
 - Tagged the pet snack machine and dog models with unique IDs for asset tracking.
 - Added an asset loader to retrieve UI components from the asset library by their unique IDs.
 - Reworked the asset loader to load IDs on the server with `InsertService` or on the client via `require`, eliminating `GetObjects` permission errors.
+- Assets are now loaded on the server and replicated to clients, removing client-side `require(assetId)` warnings.
 - Updated client scripts to return a value so they can be required without runtime failures.
 - Corrected `DogModelManager` to use `OnServerEvent` instead of `OnClientEvent`, resolving the server-side event error.
 - Fixed building component positions by assigning explicit CFrames, preventing structures from spawning below the ground level.

--- a/src/server/Remotes.luau
+++ b/src/server/Remotes.luau
@@ -2,6 +2,21 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Remotes = {}
 
+-- Asset Loading
+Remotes.LoadAsset = Instance.new("RemoteFunction")
+Remotes.LoadAsset.Name = "LoadAsset"
+Remotes.LoadAsset.Parent = ReplicatedStorage
+
+local LoadedAssets = Instance.new("Folder")
+LoadedAssets.Name = "LoadedAssets"
+LoadedAssets.Parent = ReplicatedStorage
+
+Remotes.LoadAsset.OnServerInvoke = function(_, assetId)
+    local AssetLoader = require(ReplicatedStorage.Shared.AssetLoader)
+    AssetLoader.loadAsset(assetId)
+    return true
+end
+
 -- Dog Coins & Inventory
 Remotes.UpdateDogCoins = Instance.new("RemoteEvent")
 Remotes.UpdateDogCoins.Name = "UpdateDogCoins"

--- a/src/shared/AssetLoader.luau
+++ b/src/shared/AssetLoader.luau
@@ -1,5 +1,8 @@
 local InsertService = game:GetService("InsertService")
 local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local AssetsFolder = ReplicatedStorage:WaitForChild("LoadedAssets")
 
 local AssetLoader = {}
 
@@ -10,21 +13,40 @@ function AssetLoader.loadAsset(assetId)
         return nil
     end
 
-    local ok, result = pcall(function()
-        if RunService:IsServer() then
-            local model = InsertService:LoadAsset(numericId)
-            return model and model:GetChildren()[1]
-        else
-            return require(numericId)
+    if RunService:IsServer() then
+        local existing = AssetsFolder:FindFirstChild(tostring(assetId))
+        if existing then
+            return existing:Clone()
         end
-    end)
 
-    if ok and result then
-        return result
-    else
-        warn("Failed to load asset with ID " .. tostring(assetId) .. ": " .. tostring(result))
-
+        local ok, model = pcall(function()
+            return InsertService:LoadAsset(numericId)
+        end)
+        if ok and model then
+            local obj = model:GetChildren()[1]
+            if obj then
+                obj.Name = tostring(assetId)
+                obj.Parent = AssetsFolder
+                return obj:Clone()
+            end
+        end
+        warn("Failed to load asset with ID " .. tostring(assetId) .. ": " .. tostring(model))
         return nil
+    else
+        local asset = AssetsFolder:FindFirstChild(tostring(assetId))
+        if not asset then
+            local loadRemote = ReplicatedStorage:WaitForChild("LoadAsset")
+            local ok = pcall(function()
+                loadRemote:InvokeServer(assetId)
+            end)
+            if ok then
+                asset = AssetsFolder:WaitForChild(tostring(assetId))
+            else
+                warn("Failed to load asset with ID " .. tostring(assetId))
+                return nil
+            end
+        end
+        return asset and asset:Clone() or nil
     end
 end
 


### PR DESCRIPTION
## Summary
- add LoadAsset remote to fetch assets server-side
- replicate loaded assets to clients and update AssetLoader
- document server-side asset loading

## Testing
- `rojo build -o out.rbxl` *(fails: command not found)*
- `cargo install --locked rojo` *(fails: 403 when downloading)*
- `luau-lint src` *(fails: command not found)*
- `npm install -g @roblox/luau-lsp` *(fails: 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896e7376810832197777e862052ced1