### PR TITLE
Handle unauthorized asset load gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All core gameplay features have been implemented. The next step is to replace th
 
 ### Recent Fixes
 
+- Gracefully handle unauthorized asset loads by returning failure status and avoiding infinite waits on clients.
 - Fixed `CompleteDogRequest` invocation in `DogInteractionGui` to prevent nil reference errors.
 - Reduced snack machine dog adoption chance to 20%.
 - Dogs now follow their owners while keeping a short distance to avoid overlap.

--- a/src/server/Remotes.luau
+++ b/src/server/Remotes.luau
@@ -13,8 +13,8 @@ LoadedAssets.Parent = ReplicatedStorage
 
 Remotes.LoadAsset.OnServerInvoke = function(_, assetId)
     local AssetLoader = require(ReplicatedStorage.Shared.AssetLoader)
-    AssetLoader.loadAsset(assetId)
-    return true
+    local loaded = AssetLoader.loadAsset(assetId)
+    return loaded ~= nil
 end
 
 -- Dog Coins & Inventory

--- a/src/shared/AssetLoader.luau
+++ b/src/shared/AssetLoader.luau
@@ -36,11 +36,15 @@ function AssetLoader.loadAsset(assetId)
         local asset = AssetsFolder:FindFirstChild(tostring(assetId))
         if not asset then
             local loadRemote = ReplicatedStorage:WaitForChild("LoadAsset")
-            local ok = pcall(function()
-                loadRemote:InvokeServer(assetId)
+            local ok, loaded = pcall(function()
+                return loadRemote:InvokeServer(assetId)
             end)
-            if ok then
-                asset = AssetsFolder:WaitForChild(tostring(assetId))
+            if ok and loaded then
+                asset = AssetsFolder:WaitForChild(tostring(assetId), 5)
+                if not asset then
+                    warn("Failed to load asset with ID " .. tostring(assetId))
+                    return nil
+                end
             else
                 warn("Failed to load asset with ID " .. tostring(assetId))
                 return nil


### PR DESCRIPTION
## Summary
- return asset load status from `LoadAsset` remote
- avoid infinite waits when assets fail to load by checking results and adding timeout
- document asset load handling improvement

## Testing
- `rojo build -o dummy.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e9eb80b88321b20e67d8f7ad6476