### PR TITLE
Handle missing adoption center UI when asset fails to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All core gameplay features have been implemented. The next step is to replace th
 
 ### Recent Fixes
 
+- Guard against missing adoption center UI to prevent nil `DogList` errors when assets fail to load.
 - Gracefully handle unauthorized asset loads by returning failure status and avoiding infinite waits on clients.
 - Fixed `CompleteDogRequest` invocation in `DogInteractionGui` to prevent nil reference errors.
 - Reduced snack machine dog adoption chance to 20%.

--- a/src/client/AdoptionCenterGui.luau
+++ b/src/client/AdoptionCenterGui.luau
@@ -39,6 +39,11 @@ local function buyDog(dogName)
 end
 
 local function updateDogList(dogs)
+    if not dogList then
+        warn("AdoptionCenterGui: DogList not found")
+        return
+    end
+
     for _, child in ipairs(dogList:GetChildren()) do
         if child:IsA("Frame") then
             child:Destroy()
@@ -65,10 +70,12 @@ local function updateDogList(dogs)
     end
 end
 
-AdoptionCenterRestocked.OnClientEvent:Connect(updateDogList)
+if dogList then
+    AdoptionCenterRestocked.OnClientEvent:Connect(updateDogList)
 
--- Initial fetch
-local initialDogs = GetAdoptionDogs:InvokeServer()
-updateDogList(initialDogs)
+    -- Initial fetch
+    local initialDogs = GetAdoptionDogs:InvokeServer()
+    updateDogList(initialDogs)
+end
 
 return true


### PR DESCRIPTION
## Summary
- Avoid nil access when the adoption center GUI fails to load by checking for a missing DogList
- Document the guard in README

## Testing
- `rojo build -o test-out.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896eb421aa883218fd335fe204d9378