### PR TITLE
Handle missing DogInventoryGui and private assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ All core gameplay features have been implemented. The next step is to replace th
 
 ### Recent Fixes
 
+- Added timeouts and fallback loading for `DogInventoryGui` in `DogInteractionGui`, avoiding infinite yields when the UI is missing.
+- Improved `AssetLoader` warnings to hint when assets are private or inaccessible.
 - Guard against missing adoption center UI to prevent nil `DogList` errors when assets fail to load.
 - Gracefully handle unauthorized asset loads by returning failure status and avoiding infinite waits on clients.
 - Fixed `CompleteDogRequest` invocation in `DogInteractionGui` to prevent nil reference errors.

--- a/src/client/DogInteractionGui.luau
+++ b/src/client/DogInteractionGui.luau
@@ -5,10 +5,26 @@ local CompleteDogRequest = ReplicatedStorage:WaitForChild("CompleteDogRequest")
 local DogRequestUpdate = ReplicatedStorage:WaitForChild("DogRequestUpdate")
 local NewDogAlert = ReplicatedStorage:WaitForChild("NewDogAlert")
 
+local AssetLoader = require(ReplicatedStorage.Shared.AssetLoader)
+local AssetIds = require(ReplicatedStorage.Shared.AssetIds)
+
 local player = Players.LocalPlayer
 local playerGui = player:WaitForChild("PlayerGui")
 
-local inventoryFrame = playerGui:WaitForChild("DogInventoryGui"):WaitForChild("InventoryFrame")
+local inventoryGui = playerGui:FindFirstChild("DogInventoryGui")
+if not inventoryGui then
+    inventoryGui = AssetLoader.loadGui(AssetIds.DogInventoryGui, playerGui)
+end
+if not inventoryGui then
+    warn("DogInventoryGui missing; requests UI will not show")
+    return true
+end
+
+local inventoryFrame = inventoryGui:WaitForChild("InventoryFrame", 5)
+if not inventoryFrame then
+    warn("DogInventoryGui is missing InventoryFrame")
+    return true
+end
 
 local function completeRequest(dogId)
     local success = CompleteDogRequest:InvokeServer(dogId)

--- a/src/shared/AssetLoader.luau
+++ b/src/shared/AssetLoader.luau
@@ -29,8 +29,15 @@ function AssetLoader.loadAsset(assetId)
                 obj.Parent = AssetsFolder
                 return obj:Clone()
             end
+        else
+            local msg = tostring(model)
+            warn("Failed to load asset with ID " .. tostring(assetId) .. ": " .. msg)
+            if msg:find("not authorized") then
+                warn("Ensure the asset is public or that this experience has permission to use it.")
+            end
+            return nil
         end
-        warn("Failed to load asset with ID " .. tostring(assetId) .. ": " .. tostring(model))
+        warn("Failed to load asset with ID " .. tostring(assetId))
         return nil
     else
         local asset = AssetsFolder:FindFirstChild(tostring(assetId))


### PR DESCRIPTION
## Summary
- Avoid infinite yield by loading DogInventoryGui with a timeout fallback
- Warn when assets fail to load due to authorization issues
- Document new safeguards in README

## Testing
- `cargo install rojo --locked` *(failed: download of config.json failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897d1193490832191c54ed721582dbc